### PR TITLE
ValidationErrorLocInner not imported in JS API

### DIFF
--- a/src/components/FunctionIndex.js
+++ b/src/components/FunctionIndex.js
@@ -21,22 +21,11 @@ function FunctionIndex(props) {
         console.log("Function clicked:", function_id);
         const t = new FunctionApi();
         console.log("FunctionApi:", t)
-        // TODO check how API calls (to Flask) were working, and the syntax in general
-        // t.listFunctions()
-        //     .then(response => {
-        //         if (!response.ok) {
-        //             throw new Error('Network response was not ok');
-        //         }
-        //         return response.json();
-        //     })
-        //     .then(console.log) // just logging
-        //     .catch(error => console.error('Error:', error));
         t.listFunctions(
             (error, response, body) => {
                 if (error || response.statusCode !== 200) {
                     return { type: 'error', message: error.message };
                 }
-
                 console.log(response);
                 console.log(body);
             }

--- a/src/functions-api-js-client/src/ApiClient.js
+++ b/src/functions-api-js-client/src/ApiClient.js
@@ -47,11 +47,11 @@ class ApiClient {
         this.authentications = {
         }
 
-	/**
-         * The default HTTP headers to be included for all API calls.
-         * @type {Array.<String>}
-         * @default {}
-         */
+        /**
+             * The default HTTP headers to be included for all API calls.
+             * @type {Array.<String>}
+             * @default {}
+             */
         this.defaultHeaders = {
             'User-Agent': 'OpenAPI-Generator/0.0.1/Javascript'
         };
@@ -71,11 +71,11 @@ class ApiClient {
          */
         this.cache = true;
 
-	/**
-         * If set to true, the client will save the cookies from each server
-         * response, and return them in the next request.
-         * @default false
-         */
+        /**
+             * If set to true, the client will save the cookies from each server
+             * response, and return them in the next request.
+             * @default false
+             */
         this.enableCookies = false;
 
         /*
@@ -83,13 +83,13 @@ class ApiClient {
          * if this.enableCookies is set to true.
          */
         if (typeof window === 'undefined') {
-          this.agent = new superagent.agent();
+            this.agent = new superagent.agent();
         }
 
         /*
          * Allow user to override superagent agent
          */
-         this.requestAgent = null;
+        this.requestAgent = null;
 
         /*
          * Allow user to add superagent plugins
@@ -133,14 +133,14 @@ class ApiClient {
         }
     };
 
-   /**
-    * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
-    * NOTE: query parameters are not handled here.
-    * @param {String} path The path to append to the base URL.
-    * @param {Object} pathParams The parameter values to append.
-    * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
-    * @returns {String} The encoded path with parameter values substituted.
-    */
+    /**
+     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
+     * NOTE: query parameters are not handled here.
+     * @param {String} path The path to append to the base URL.
+     * @param {Object} pathParams The parameter values to append.
+     * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
+     * @returns {String} The encoded path with parameter values substituted.
+     */
     buildUrl(path, pathParams, apiBasePath) {
         if (!path.match(/^\//)) {
             path = '/' + path;
@@ -208,7 +208,7 @@ class ApiClient {
             let fs;
             try {
                 fs = require('fs');
-            } catch (err) {}
+            } catch (err) { }
             if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
                 return true;
             }
@@ -306,9 +306,9 @@ class ApiClient {
                 case 'bearer':
                     if (auth.accessToken) {
                         var localVarBearerToken = typeof auth.accessToken === 'function'
-                          ? auth.accessToken()
-                          : auth.accessToken
-                        request.set({'Authorization': 'Bearer ' + localVarBearerToken});
+                            ? auth.accessToken()
+                            : auth.accessToken
+                        request.set({ 'Authorization': 'Bearer ' + localVarBearerToken });
                     }
 
                     break;
@@ -331,7 +331,7 @@ class ApiClient {
                     break;
                 case 'oauth2':
                     if (auth.accessToken) {
-                        request.set({'Authorization': 'Bearer ' + auth.accessToken});
+                        request.set({ 'Authorization': 'Bearer ' + auth.accessToken });
                     }
 
                     break;
@@ -341,15 +341,15 @@ class ApiClient {
         });
     }
 
-   /**
-    * Deserializes an HTTP response body into a value of the specified type.
-    * @param {Object} response A SuperAgent response object.
-    * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
-    * or the constructor function for a complex type. Pass an array containing the type name to return an array of that type. To
-    * return an object, pass an object with one property whose name is the key type and whose value is the corresponding value type:
-    * all properties on <code>data<code> will be converted to this type.
-    * @returns A value of the specified type.
-    */
+    /**
+     * Deserializes an HTTP response body into a value of the specified type.
+     * @param {Object} response A SuperAgent response object.
+     * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
+     * or the constructor function for a complex type. Pass an array containing the type name to return an array of that type. To
+     * return an object, pass an object with one property whose name is the key type and whose value is the corresponding value type:
+     * all properties on <code>data<code> will be converted to this type.
+     * @returns A value of the specified type.
+     */
     deserialize(response, returnType) {
         if (response == null || returnType == null || response.status == 204) {
             return null;
@@ -366,32 +366,32 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-   /**
-    * Callback function to receive the result of the operation.
-    * @callback module:ApiClient~callApiCallback
-    * @param {String} error Error message, if any.
-    * @param data The data returned by the service call.
-    * @param {String} response The complete HTTP response.
-    */
+    /**
+     * Callback function to receive the result of the operation.
+     * @callback module:ApiClient~callApiCallback
+     * @param {String} error Error message, if any.
+     * @param data The data returned by the service call.
+     * @param {String} response The complete HTTP response.
+     */
 
-   /**
-    * Invokes the REST service using the supplied settings and parameters.
-    * @param {String} path The base URL to invoke.
-    * @param {String} httpMethod The HTTP method to use.
-    * @param {Object.<String, String>} pathParams A map of path parameters and their values.
-    * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
-    * @param {Object.<String, Object>} headerParams A map of header parameters and their values.
-    * @param {Object.<String, Object>} formParams A map of form parameters and their values.
-    * @param {Object} bodyParam The value to pass as the request body.
-    * @param {Array.<String>} authNames An array of authentication type names.
-    * @param {Array.<String>} contentTypes An array of request MIME types.
-    * @param {Array.<String>} accepts An array of acceptable response MIME types.
-    * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
-    * constructor for a complex type.
-    * @param {String} apiBasePath base path defined in the operation/path level to override the default one
-    * @param {module:ApiClient~callApiCallback} callback The callback function.
-    * @returns {Object} The SuperAgent request object.
-    */
+    /**
+     * Invokes the REST service using the supplied settings and parameters.
+     * @param {String} path The base URL to invoke.
+     * @param {String} httpMethod The HTTP method to use.
+     * @param {Object.<String, String>} pathParams A map of path parameters and their values.
+     * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
+     * @param {Object.<String, Object>} headerParams A map of header parameters and their values.
+     * @param {Object.<String, Object>} formParams A map of form parameters and their values.
+     * @param {Object} bodyParam The value to pass as the request body.
+     * @param {Array.<String>} authNames An array of authentication type names.
+     * @param {Array.<String>} contentTypes An array of request MIME types.
+     * @param {Array.<String>} accepts An array of acceptable response MIME types.
+     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
+     * constructor for a complex type.
+     * @param {String} apiBasePath base path defined in the operation/path level to override the default one
+     * @param {module:ApiClient~callApiCallback} callback The callback function.
+     * @returns {Object} The SuperAgent request object.
+     */
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
         returnType, apiBasePath, callback) {
@@ -422,7 +422,7 @@ class ApiClient {
 
         // set requestAgent if it is set by user
         if (this.requestAgent) {
-          request.agent(this.requestAgent);
+            request.agent(this.requestAgent);
         }
 
         // set request timeout
@@ -431,14 +431,14 @@ class ApiClient {
         var contentType = this.jsonPreferredMime(contentTypes);
         if (contentType) {
             // Issue with superagent and multipart/form-data (https://github.com/visionmedia/superagent/issues/746)
-            if(contentType != 'multipart/form-data') {
+            if (contentType != 'multipart/form-data') {
                 request.type(contentType);
             }
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
             let normalizedParams = this.normalizeParams(formParams)
-            let urlSearchParams =  new URLSearchParams(normalizedParams);
+            let urlSearchParams = new URLSearchParams(normalizedParams);
             let queryString = urlSearchParams.toString();
             request.send(queryString);
         } else if (contentType == 'multipart/form-data') {
@@ -471,13 +471,13 @@ class ApiClient {
         }
 
         if (returnType === 'Blob') {
-          request.responseType('blob');
+            request.responseType('blob');
         } else if (returnType === 'String') {
-          request.responseType('text');
+            request.responseType('text');
         }
 
         // Attach previously saved cookies, if enabled
-        if (this.enableCookies){
+        if (this.enableCookies) {
             if (typeof window === 'undefined') {
                 this.agent._attachCookies(request);
             }
@@ -492,7 +492,7 @@ class ApiClient {
                 if (!error) {
                     try {
                         data = this.deserialize(response, returnType);
-                        if (this.enableCookies && typeof window === 'undefined'){
+                        if (this.enableCookies && typeof window === 'undefined') {
                             this.agent._saveCookies(response);
                         }
                     } catch (err) {
@@ -587,20 +587,20 @@ class ApiClient {
         }
     }
 
-  /**
-    * Gets an array of host settings
-    * @returns An array of host settings
-    */
+    /**
+      * Gets an array of host settings
+      * @returns An array of host settings
+      */
     hostSettings() {
         return [
             {
-              'url': "",
-              'description': "No description provided",
+                'url': "",
+                'description': "No description provided",
             }
-      ];
+        ];
     }
 
-    getBasePathFromSettings(index, variables={}) {
+    getBasePathFromSettings(index, variables = {}) {
         var servers = this.hostSettings();
 
         // check array index out of bound
@@ -615,7 +615,7 @@ class ApiClient {
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
                 let variable = server['variables'][variable_name];
-                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
+                if (!('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name])) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/src/functions-api-js-client/src/model/ValidationError.js
+++ b/src/functions-api-js-client/src/model/ValidationError.js
@@ -12,7 +12,7 @@
  */
 
 import ApiClient from '../ApiClient';
-import ValidationErrorLocInner from './ValidationErrorLocInner';
+// import ValidationErrorLocInner from './ValidationErrorLocInner';
 
 /**
  * The ValidationError model module.
@@ -27,8 +27,8 @@ class ValidationError {
      * @param msg {String} 
      * @param type {String} 
      */
-    constructor(loc, msg, type) { 
-        
+    constructor(loc, msg, type) {
+
         ValidationError.initialize(this, loc, msg, type);
     }
 
@@ -37,7 +37,7 @@ class ValidationError {
      * This method is used by the constructors of any subclasses, in order to implement multiple inheritance (mix-ins).
      * Only for internal use.
      */
-    static initialize(obj, loc, msg, type) { 
+    static initialize(obj, loc, msg, type) {
         obj['loc'] = loc;
         obj['msg'] = msg;
         obj['type'] = type;
@@ -54,9 +54,9 @@ class ValidationError {
         if (data) {
             obj = obj || new ValidationError();
 
-            if (data.hasOwnProperty('loc')) {
-                obj['loc'] = ApiClient.convertToType(data['loc'], [ValidationErrorLocInner]);
-            }
+            // if (data.hasOwnProperty('loc')) {
+            //     obj['loc'] = ApiClient.convertToType(data['loc'], [ValidationErrorLocInner]);
+            // }
             if (data.hasOwnProperty('msg')) {
                 obj['msg'] = ApiClient.convertToType(data['msg'], 'String');
             }
@@ -84,10 +84,10 @@ class ValidationError {
             if (!Array.isArray(data['loc'])) {
                 throw new Error("Expected the field `loc` to be an array in the JSON data but got " + data['loc']);
             }
-            // validate the optional field `loc` (array)
-            for (const item of data['loc']) {
-                ValidationErrorLocInner.validateJSON(item);
-            };
+            // // validate the optional field `loc` (array)
+            // for (const item of data['loc']) {
+            //     ValidationErrorLocInner.validateJSON(item);
+            // };
         }
         // ensure the json data is a string
         if (data['msg'] && !(typeof data['msg'] === 'string' || data['msg'] instanceof String)) {
@@ -107,7 +107,7 @@ class ValidationError {
 ValidationError.RequiredProperties = ["loc", "msg", "type"];
 
 /**
- * @member {Array.<module:model/ValidationErrorLocInner>} loc
+//  * @member {Array.<module:model/ValidationErrorLocInner>} loc
  */
 ValidationError.prototype['loc'] = undefined;
 


### PR DESCRIPTION
Generation of the JavaScript API by the [OpenAPI-generator-cli](https://github.com/ITISFoundation/functions_api/blob/2090e00d87976cdf2d62f7aa4a22dd9b8fbd914c/Makefile#L25) seems to be broken - the [ValidationErrorLocInner](https://github.com/ITISFoundation/functions_api/blob/main/functions-api-js-client/src/model/ValidationErrorLocInner.js) module is generated virtually empty and without an export statement, which generates an error when importing most classes in the Functions API package / folder.

```
Failed to compile.

Attempted import error: './ValidationErrorLocInner' does not contain a default export (imported as 'ValidationErrorLocInner').
ERROR in ./src/functions-api-js-client/src/model/ValidationError.js 58:59-82
export 'default' (imported as 'ValidationErrorLocInner') was not found in './ValidationErrorLocInner' (module has no exports)

ERROR in ./src/functions-api-js-client/src/model/ValidationError.js 90:8-44
export 'default' (imported as 'ValidationErrorLocInner') was not found in './ValidationErrorLocInner' (module has no exports)

webpack compiled with 2 errors
```